### PR TITLE
Refresh Synchronic Web docs for bridges and general bootstrap

### DIFF
--- a/info/README.md
+++ b/info/README.md
@@ -85,4 +85,4 @@ python3 generate.py
 docker compose up
 ```
 
-That harness reuses the full `sync-services` general stack per node and is the current local path for testing peer topology behavior without FIREWHEEL.
+That harness reuses the full `sync-services` general stack per node and is the current local path for testing bridge topology behavior without FIREWHEEL.

--- a/info/package.json
+++ b/info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sync-web-info",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Synchronic Web documentation site (Astro + Starlight).",
   "scripts": {
     "dev": "astro dev",

--- a/info/scripts/capture-screenshots-with-stack.sh
+++ b/info/scripts/capture-screenshots-with-stack.sh
@@ -59,7 +59,7 @@ dc up -d --build
 echo "Waiting for UI routes..."
 wait_for_http "http://127.0.0.1:$PORT/explorer/"
 wait_for_http "http://127.0.0.1:$PORT/workbench/"
-wait_for_http "http://127.0.0.1:$PORT/gateway/"
+wait_for_http "http://127.0.0.1:$PORT/docs"
 
 echo "Capturing screenshots..."
 SYNC_BASE_URL="http://127.0.0.1:$PORT" npm --prefix "$INFO_DIR" run capture:screenshots

--- a/info/scripts/capture-screenshots.mjs
+++ b/info/scripts/capture-screenshots.mjs
@@ -24,7 +24,7 @@ const targets = [
   },
   {
     key: "gateway",
-    url: `${baseUrl}/api/v1/docs`,
+    url: `${baseUrl}/docs`,
     selector: "body",
   },
 ];

--- a/info/src/content/docs/development.md
+++ b/info/src/content/docs/development.md
@@ -6,7 +6,7 @@ sidebar:
 head: []
 ---
 This section is for developers extending runtime behavior, class logic, and APIs.
-The core pattern is progressive layering through `interface.scm` and class modules loaded at boot.
+The core pattern is progressive layering through `general.scm` and the class modules loaded at boot.
 
 ## Architecture
 
@@ -23,7 +23,7 @@ The general stack boot flow is:
 2. Install/instantiate `standard.scm`.
 3. Install class definitions (`log-chain.scm`, `tree.scm`, `configuration.scm`, `ledger.scm`).
 4. Instantiate and store `ledger` object.
-5. Install interface secret and query dispatcher.
+5. Install general API secret and query dispatcher.
 
 Concurrency behavior in `sync-journal` is optimistic:
 
@@ -147,7 +147,7 @@ These signatures are sourced from primitive registrations in `sync-journal/src/e
 | `crypto-sign` | `(crypto-sign private-key message)` | Sign message with private key. |
 | `crypto-verify` | `(crypto-verify public-key signature message)` | Verify signature against message/public key. |
 
-When adding new primitives, keep conversion behavior and security constraints in mind so JSON/Lisp workflows remain predictable.
+When adding new primitives, keep conversion behavior and security constraints in mind so JSON/Scheme workflows remain predictable.
 
 ### Standard Objects
 
@@ -266,18 +266,20 @@ Public API (`ledger.scm`):
 | `configuration` | `(configuration self)` | Return full configuration (public + private). |
 | `information` | `(information self)` | Return public configuration subset. |
 | `size` | `(size self)` | Return permanent chain length. |
-| `peer!` | `(peer! self name info)` | Register/update peer metadata and cached public key. |
-| `peers` | `(peers self)` | List configured peer names. |
+| `bridge!` | `(bridge! self name info)` | Register/update bridge metadata and cached public key. |
+| `bridges` | `(bridges self)` | List configured bridge names. |
 | `set!` | `(set! self path value)` | Stage local state mutation. |
-| `get` | `(get self path details?)` | Read staged/historical value; optional content/pinned/proof bundle. |
+| `get` | `(get self path pinned? proof?)` | Read staged/historical value; optional content/pinned/proof bundle. |
 | `pin!` | `(pin! self path)` | Pin path into permanent chain retention. |
 | `unpin!` | `(unpin! self path)` | Remove previously pinned path. |
-| `synchronize` | `(synchronize self index)` | Serialize peer-sync proof view at index. |
+| `synchronize` | `(synchronize self index)` | Serialize bridge-sync proof view at index. |
 | `resolve` | `(resolve self index path)` | Serialize resolved path view for remote verification. |
-| `step-peer!` | `(step-peer! self name)` | Fetch and verify peer chain head into staged state. |
+| `step-bridge!` | `(step-bridge! self name)` | Fetch and verify bridge chain head into staged state. |
 | `step-chain!` | `(step-chain! self)` | Commit staged state to chain, sign, prune by window, return new size. |
-| `step-generate` | `(step-generate self)` | Generate ordered step operations (chain + peers). |
-| `*update*` | `(*update* self class function)` | Return updated ledger object after applying class-scoped transformation. |
+| `step-generate` | `(step-generate self)` | Generate ordered step operations (chain + bridges). |
+| `update-window` | `(update-window self window)` | Update the configured recent-history window and prune `temp` when it shrinks. |
+| `update-config!` | `(update-config! self path value)` | Update a configuration entry in place. |
+| `update-code!` | `(update-code! self class update!)` | Update one surface-level code object in place. |
 
 ## Testing
 
@@ -314,8 +316,8 @@ Use `sync-services/tests` when you need to validate the integrated runtime plus 
 
 - `/explorer`
 - `/workbench`
-- `/gateway`
-- `/interface/json`
+- `/docs`
+- `/api/v1/...`
 - the SMB-backed file-system projection
 
 Prerequisites:
@@ -374,11 +376,11 @@ dotnet test tests/FileSystem.Server.Tests/FileSystem.Server.Tests.csproj
 
 ### Stress Testing
 
-Use `sync-analysis/locust` for HTTP load generation against journal interface endpoints.
+Use `sync-analysis/locust` for HTTP load generation against gateway general endpoints.
 
 Prerequisites:
 
-You need a running interface endpoint (typically from `sync-services`), Python 3 with `pip` and Locust dependencies from `requirements.txt`, and a `SECRET` environment variable that matches server configuration.
+You need a running gateway endpoint (typically from `sync-services`), Python 3 with `pip` and Locust dependencies from `requirements.txt`, and a `SECRET` environment variable that matches server configuration.
 
 Install and run:
 
@@ -387,7 +389,7 @@ cd /code/sync-analysis/locust
 python3 -m venv .venv
 . .venv/bin/activate
 pip install -r requirements.txt
-SECRET=pass locust --host=http://localhost:8192/interface
+SECRET=pass locust --host=http://localhost:8192
 ```
 
 Headless example:
@@ -395,7 +397,7 @@ Headless example:
 ```bash
 cd /code/sync-analysis/locust
 . .venv/bin/activate
-SECRET=pass locust --host=http://localhost:8192/interface --users=10 --spawn-rate=2 --run-time=60s --headless
+SECRET=pass locust --host=http://localhost:8192 --users=10 --spawn-rate=2 --run-time=60s --headless
 ```
 
 ### Multi-Node Compose Testing

--- a/info/src/content/docs/operation.mdx
+++ b/info/src/content/docs/operation.mdx
@@ -85,10 +85,9 @@ It serves runtime query routes and UI routes:
 
 | Route | Purpose |
 | --- | --- |
-| `/interface` | Lisp request endpoint for direct evaluator and API calls. |
+| `/interface` | Scheme request endpoint for direct evaluator and API calls. |
 | `/interface/json` | JSON request endpoint for web and service integrations. |
-| `/gateway/` | Gateway landing page and route orientation. |
-| `/api/v1/docs` | Swagger/OpenAPI documentation for versioned API routes. |
+| `/docs` | Gateway Swagger/OpenAPI documentation and route orientation. |
 | `/api/v1/...` | Versioned gateway API endpoints proxied to gateway service. |
 | `/explorer/` | Browser UI with dedicated `Ledger` and `Stage` modes for committed browsing and local staged editing. |
 | `/workbench/` | Developer-oriented query workspace with API aids. |
@@ -101,7 +100,7 @@ Router mode is selected at startup:
 
 ## Network API
 
-Implemented by `compose/general/interface.scm` on top of `control.scm` and `ledger.scm`.
+Implemented by `sync-records/lisp/general.scm` on top of `control.scm` and `ledger.scm`.
 Permission boundaries are central to safe operation, so operators should treat function families as security domains.
 
 ### Function Families
@@ -109,7 +108,7 @@ Permission boundaries are central to safe operation, so operators should treat f
 | Family | Description | Functions |
 | --- | --- | --- |
 | Public (no authentication) | Read-only methods intended for external visibility without secrets. | `size`, `synchronize`, `resolve`, `information` |
-| Restricted (interface secret) | Stateful or sensitive operations that require interface authentication. | `get`, `set!`, `pin!`, `unpin!`, `general-peer!`, `peer!`, `peers`, `configuration`, `step-generate`, `step-chain!`, `step-peer!`, `*secret*` |
+| Restricted (interface secret) | Stateful or sensitive operations that require interface authentication. | `get`, `set!`, `pin!`, `unpin!`, `general-bridge!`, `bridge!`, `bridges`, `general-batch!`, `configuration`, `step-generate`, `step-chain!`, `step-bridge!`, `*secret*` |
 | Root/Admin control | Root control commands for runtime mutation and administrative lifecycle management. | `*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*` |
 
 ### Function Reference
@@ -122,7 +121,7 @@ The same function names appear in Explorer/Workbench, automated scripts, and inc
 | Function | Purpose |
 | --- | --- |
 | `size` | Current permanent-chain size |
-| `synchronize` | Serialize digest/proof data for peer sync |
+| `synchronize` | Serialize digest/proof data for bridge sync |
 | `resolve` | Resolve and serialize state at a path/index |
 | `information` | Public node metadata (e.g., public key/window) |
 
@@ -134,20 +133,20 @@ The same function names appear in Explorer/Workbench, automated scripts, and inc
 | `set!` | Stage a write |
 | `pin!` | Persist proof/data in permanent chain |
 | `unpin!` | Remove persisted pin |
-| `general-peer!` | Register peer from URL helper |
-| `peer!` | Register peer with explicit RPC handlers |
-| `peers` | List configured peers |
+| `general-bridge!` | Register bridge from URL helper |
+| `bridge!` | Register bridge with explicit RPC handlers |
+| `bridges` | List configured bridges |
 | `configuration` | Return full public/private config |
 | `step-generate` | Build ordered step actions |
 | `step-chain!` | Commit staged state to chain |
-| `step-peer!` | Sync state from a named peer |
+| `step-bridge!` | Sync state from a named bridge |
 | `*secret*` | Rotate interface secret |
 
 #### Root/Admin Functions
 
 | Function | Purpose |
 | --- | --- |
-| `*eval*` | Evaluate arbitrary Lisp in admin context |
+| `*eval*` | Evaluate arbitrary Scheme in admin context |
 | `*call*` | Invoke function with root object |
 | `*step*` | Execute full step cycle |
 | `*set-secret*` | Rotate root/admin secret |
@@ -185,10 +184,10 @@ These are public control commands handled by the transition function in `control
 
 This API is intentionally powerful and low-level, so access should be tightly controlled and audited.
 
-### General Interface API
+### General API Bootstrap
 
-`interface.scm` overlays the instantiated ledger object and dispatches `((function ...))` requests to public ledger methods, with permission checks on each call.
-It also adds one integration helper (`general-peer!`) that composes the lower-level peer registration flow.
+`general.scm` overlays the instantiated ledger object and dispatches `((function ...))` requests to public ledger methods, with permission checks on each call.
+It also adds one integration helper (`general-bridge!`) that composes the lower-level bridge registration flow.
 
 #### General API Methods
 
@@ -202,13 +201,14 @@ It also adds one integration helper (`general-peer!`) that composes the lower-le
 | `set!` | Restricted | Stage write to local state path. |
 | `pin!` | Restricted | Persist selected path/proof in permanent chain. |
 | `unpin!` | Restricted | Remove previously pinned path/proof. |
-| `general-peer!` | Restricted | Add peer from URL and auto-wire `information/synchronize/resolve` handlers. |
-| `peer!` | Restricted | Add peer with explicit handler expressions. |
-| `peers` | Restricted | List configured peer names. |
+| `general-bridge!` | Restricted | Add bridge from URL and auto-wire `information/synchronize/resolve` handlers. |
+| `bridge!` | Restricted | Add bridge with explicit handler expressions. |
+| `bridges` | Restricted | List configured bridge names. |
+| `general-batch!` | Restricted | Execute an ordered list of general-interface requests under one authenticated call. |
 | `configuration` | Restricted | Return full configuration (including private fields). |
 | `step-generate` | Restricted | Generate ordered step actions. |
 | `step-chain!` | Restricted | Commit staged state and advance chain. |
-| `step-peer!` | Restricted | Synchronize a named peer into local staged state. |
+| `step-bridge!` | Restricted | Synchronize a named bridge into local staged state. |
 | `*secret*` | Restricted | Rotate interface secret used by general API auth checks. |
 
 Root commands (`*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*`) are also callable, but remain part of the control-plane surface and should be treated as admin-level operations.

--- a/info/src/content/docs/usage.mdx
+++ b/info/src/content/docs/usage.mdx
@@ -13,7 +13,7 @@ It focuses on the currently deployed `general` interface shape used by `sync-ser
 
 ## Graphical Interface
 
-The `general` compose network exposes three primary web clients and one filesystem-oriented service: Explorer (`/explorer/`), Workbench (`/workbench/`), Gateway (`/gateway/`), and File System (SMB).
+The `general` compose network exposes three primary web clients and one filesystem-oriented service: Explorer (`/explorer/`), Workbench (`/workbench/`), Gateway (`/docs` plus `/api/v1/...`), and File System (SMB).
 Together they cover the full operator/developer loop: inspect data, make changes, verify outcomes, mount journal state into ordinary file tools, and convert successful workflows into repeatable API calls.
 
 ### Explorer
@@ -23,7 +23,7 @@ It now has two explicit modes:
 
 - `Ledger`
   - the default landing mode
-  - route-based browsing of committed state across peers and snapshots
+  - route-based browsing of committed state across bridges and snapshots
 - `Stage`
   - local editable staged state
   - file and directory oriented editing actions
@@ -31,7 +31,7 @@ It now has two explicit modes:
 Typical Explorer workflow:
 
 1. Start in `Ledger` and synchronize to the latest committed root.
-2. Use the route strip to browse from `Self` through peers and historical snapshots.
+2. Use the route strip to browse from `Self` through bridges and historical snapshots.
 3. Select a ledger file to switch between content and proof views or pin/unpin it.
 4. Switch to `Stage` when you want to edit local staged files and directories.
 5. Use stage actions to create documents/directories, upload files, edit content, and download files.
@@ -47,8 +47,8 @@ Use it when you want precise control over requests, fast iteration on payload sh
 
 Typical Workbench workflow:
 
-1. Start from a known request pattern (for example `get`, `set!`, `pin!`, or `general-peer!`).
-2. Run the request in Lisp or JSON form and inspect the returned value.
+1. Start from a known request pattern (for example `get`, `set!`, `pin!`, or `general-bridge!`).
+2. Run the request in Scheme or JSON form and inspect the returned value.
 3. Iterate on arguments/authentication until behavior matches intent.
 4. Use the final request as a template for automation or service integration.
 
@@ -63,8 +63,8 @@ Use it when clients should call stable, versioned HTTP routes instead of direct 
 
 Typical Gateway workflow:
 
-1. Start with `GET /gateway/` for route orientation.
-2. Use `GET /api/v1/docs` to review request and response schemas.
+1. Start with `GET /docs` to review request and response schemas.
+2. Use `GET /api/v1/general/size` or another stable route to validate connectivity.
 3. Execute public general operations through `GET` routes (for example `size`, `information`, and `resolve`).
 4. Execute restricted `general` and optional `control` operations through authenticated `POST` routes.
 5. Move validated requests into application clients or automation scripts using the same gateway contracts.
@@ -83,7 +83,7 @@ Typical File System workflow:
 1. Mount the share and work in `/stage` for ordinary mutable file operations.
 2. Browse `/ledger/state` for current committed content.
 3. Traverse `/ledger/previous/<index>/state` for prior committed states.
-4. Traverse `/ledger/peer/<name>/...` for recursively peered ledger state.
+4. Traverse `/ledger/bridge/<name>/...` for recursively bridged ledger state.
 5. Use `/control/pin` for explicit pin and unpin directives on discovered ledger paths.
 
 The File System service is best for shell tools, editors, archives, source trees, and other workflows that already expect a hierarchical filesystem.
@@ -100,12 +100,12 @@ Filesystem projection overview:
 │   ├── previous/
 │   │   └── <index>/
 │   │       ├── state/
-│   │       ├── peer/
+│   │       ├── bridge/
 │   │       └── previous/
-│   └── peer/
+│   └── bridge/
 │       └── <name>/
 │           ├── state/
-│           ├── peer/
+│           ├── bridge/
 │           └── previous/
 └── control/
     └── pin
@@ -130,10 +130,10 @@ The two execution endpoints (`/interface`, `/interface/json`) are for runtime ca
 
 | Endpoint | Description |
 | --- | --- |
-| `POST /interface` | Executes Lisp requests directly against the interface runtime. |
+| `POST /interface` | Executes Scheme requests directly against the interface runtime. |
 | `POST /interface/json` | Executes JSON requests using the object-shaped API envelope. |
-| `POST /interface/lisp-to-json` | Converts Lisp expressions into JSON payload representations. |
-| `POST /interface/json-to-lisp` | Converts JSON payloads back into Lisp forms for debugging and validation. |
+| `POST /interface/scheme-to-json` | Converts Scheme expressions into JSON payload representations. |
+| `POST /interface/json-to-scheme` | Converts JSON payloads back into Scheme forms for debugging and validation. |
 
 ### Request Envelope
 
@@ -148,7 +148,7 @@ That keeps client implementations simple and makes troubleshooting easier across
 
 > **Note:**
 >
-> In Lisp form, API queries are association lists. In JSON form, they are objects with equivalent fields.
+> In Scheme form, API queries are association lists. In JSON form, they are objects with equivalent fields.
 >
 ### Operation Examples
 
@@ -163,7 +163,8 @@ You can copy them into Workbench first, then move them into automation once vali
 ```scheme
 ((function get)
  (arguments ((path ((*state* docs article hash)))
-             (details? #t)))
+             (pinned? #t)
+             (proof? #t)))
  (authentication "password"))
 ```
 
@@ -175,7 +176,8 @@ You can copy them into Workbench first, then move them into automation once vali
   "function": "get",
   "arguments": {
     "path": [["*state*", "docs", "article", "hash"]],
-    "details?": true
+    "pinned?": true,
+    "proof?": true
   },
   "authentication": {"*type/string*": "password"}
 }
@@ -184,9 +186,9 @@ You can copy them into Workbench first, then move them into automation once vali
   </TabItem>
 </Tabs>
 
-> **Info: When to use `details? = true`**
+> **Info: When to use `pinned?` and `proof?`**
 >
-> Use `#t` / `true` when you need proof and pin metadata, not just content.
+> Use `pinned?` when you want to know whether a historical path remains pinned, and use `proof?` when you need the proof payload itself.
 >
 #### Write (`set!`)
 
@@ -242,13 +244,13 @@ You can copy them into Workbench first, then move them into automation once vali
   </TabItem>
 </Tabs>
 
-#### Peer (`general-peer!`)
+#### Bridge (`general-bridge!`)
 
 <Tabs syncKey="lisp-json">
   <TabItem label="Lisp">
 
 ```scheme
-((function general-peer!)
+((function general-bridge!)
  (arguments ((name journal_b)
              (interface "http://journal-b.example.org/interface")))
  (authentication "password"))
@@ -259,7 +261,7 @@ You can copy them into Workbench first, then move them into automation once vali
 
 ```json
 {
-  "function": "general-peer!",
+  "function": "general-bridge!",
   "arguments": {
     "name": "journal_b",
     "interface": {"*type/string*": "http://journal-b.example.org/interface"}
@@ -271,16 +273,16 @@ You can copy them into Workbench first, then move them into automation once vali
   </TabItem>
 </Tabs>
 
-## JSON/Lisp Conversion
+## JSON/Scheme Conversion
 
-The converter treats JSON and Lisp as structurally equivalent where possible.
+The converter treats JSON and Scheme as structurally equivalent where possible.
 
 ### Core Mapping
 
-This mapping is the key mental model for moving between web client payloads and Lisp-native request forms.
+This mapping is the key mental model for moving between web client payloads and Scheme-native request forms.
 Once this is clear, advanced payloads become much easier to reason about.
 
-| Lisp | JSON |
+| Scheme | JSON |
 | --- | --- |
 | symbol | string |
 | list | array |
@@ -292,7 +294,7 @@ Once this is clear, advanced payloads become much easier to reason about.
 Special type wrappers are only needed where plain JSON cannot preserve Lisp/runtime semantics.
 If a payload seems unexpectedly interpreted, check whether a special type marker is required.
 
-| JSON marker | Lisp value |
+| JSON marker | Scheme value |
 | --- | --- |
 | `{"*type/string*": "text"}` | string |
 | `{"*type/quoted*": ...}` | `(quote ...)` |
@@ -304,9 +306,9 @@ If a payload seems unexpectedly interpreted, check whether a special type marker
 
 ### Practical Guidance
 
-Use `/interface/lisp-to-json` to generate exact JSON for complex expressions, and use `/interface/json-to-lisp` when debugging client payloads or validating round-trip conversions.
+Use `/interface/scheme-to-json` to generate exact JSON for complex expressions, and use `/interface/json-to-scheme` when debugging client payloads or validating round-trip conversions.
 For web clients, prefer object-shaped API queries (`function`, `arguments`, `authentication`) because they remain easier to read and diff than raw array forms, and reserve array-shaped JSON for raw root command calls.
 Prefer `*type/string*` for literal strings in JSON payloads whenever you need to avoid ambiguity in type conversion.
 
-A common workflow is: prototype in Lisp, convert to JSON, integrate in client code, then round-trip with `json-to-lisp` during debugging.
+A common workflow is: prototype in Scheme, convert to JSON, integrate in client code, then round-trip with `json-to-scheme` during debugging.
 Teams that include conversion checks in their release process generally catch payload-shape regressions earlier.


### PR DESCRIPTION
- update development and operations docs to use bridge terminology consistently
- rename general-install.scm references to general.scm across the documentation set
- refresh the documented ledger update method names and related runtime descriptions
- align supporting docs and screenshot references with the current routed stack behavior