### PR TITLE
Refresh sync-web docs for the current interface and ledger model

### DIFF
--- a/info/src/content/docs/development.md
+++ b/info/src/content/docs/development.md
@@ -6,7 +6,7 @@ sidebar:
 head: []
 ---
 This section is for developers extending runtime behavior, class logic, and APIs.
-The core pattern is progressive layering through `general.scm` and the class modules loaded at boot.
+The core pattern is progressive layering through `interface.scm` and the class modules loaded at boot.
 
 ## Architecture
 
@@ -21,9 +21,9 @@ The general stack boot flow is:
 
 1. Install `control.scm`.
 2. Install/instantiate `standard.scm`.
-3. Install class definitions (`log-chain.scm`, `tree.scm`, `configuration.scm`, `ledger.scm`).
-4. Instantiate and store `ledger` object.
-5. Install general API secret and query dispatcher.
+3. Install class definitions (`log-chain.scm`, `tree.scm`, `ledger.scm`).
+4. Instantiate and store `ledger` object with inline config state.
+5. Install interface secret and query dispatcher.
 
 Concurrency behavior in `sync-journal` is optimistic:
 
@@ -119,14 +119,14 @@ These signatures are sourced from primitive registrations in `sync-journal/src/e
 | `sync-node` | `(sync-node digest)` | Load sync node identified by digest. |
 | `sync-node?` | `(sync-node? obj)` | Check whether object is a sync node. |
 | `sync-null` | `(sync-null)` | Return null sync node. |
-| `sync-null?` | `(sync-null? sp)` | Check whether node/value is null sync node. |
-| `sync-pair?` | `(sync-pair? sp)` | Check whether node is a pair node. |
-| `sync-stub?` | `(sync-stub? sp)` | Check whether node is a stub node. |
-| `sync-digest` | `(sync-digest node)` | Return digest of sync node. |
+| `sync-null?` | `(sync-null? sp)` | Check whether a sync-node or byte-vector is the null sync node. |
+| `sync-pair?` | `(sync-pair? sp)` | Check whether a sync-node or byte-vector is a pair node. |
+| `sync-stub?` | `(sync-stub? sp)` | Check whether a sync-node or byte-vector is a stub node. |
+| `sync-digest` | `(sync-digest value)` | Return digest of a sync-node or byte-vector. |
 | `sync-cons` | `(sync-cons first rest)` | Construct sync pair node. |
 | `sync-car` | `(sync-car pair)` | Return first child of sync pair. |
 | `sync-cdr` | `(sync-cdr pair)` | Return second child of sync pair. |
-| `sync-cut` | `(sync-cut value)` | Convert node/value into stub form. |
+| `sync-cut` | `(sync-cut node)` | Convert a sync-node into stub form. |
 
 #### Record Lifecycle Primitives
 
@@ -246,37 +246,26 @@ Public API (`log-chain.scm`):
 | `prune!` | `(prune! self index)` | Prune proof detail at index. |
 | `truncate!` | `(truncate! self depth)` | Truncate proof tree depth by cutting deeper nodes. |
 
-#### Configuration Class
-
-Public API (`configuration.scm`):
-
-| Method | Signature | Description |
-| --- | --- | --- |
-| `*init*` | `(*init* self (config '()))` | Initialize configuration expression state. |
-| `get` | `(get self path)` | Read nested configuration value by symbol-path. |
-| `set!` | `(set! self path value)` | Set nested value; delete branch when value is `'()`. |
-
 #### Ledger Class
 
 Public API (`ledger.scm`):
 
 | Method | Signature | Description |
 | --- | --- | --- |
-| `*init*` | `(*init* self standard config)` | Initialize ledger with standard helper and configuration object. |
-| `configuration` | `(configuration self)` | Return full configuration (public + private). |
-| `information` | `(information self)` | Return public configuration subset. |
+| `*init*` | `(*init* self standard config tree-class chain-class)` | Initialize ledger with standard helper, inline config expression, and storage classes. |
+| `config` | `(config self (path '()))` | Return full configuration or a nested configuration path. |
+| `info` | `(info self)` | Return public configuration subset. |
 | `size` | `(size self)` | Return permanent chain length. |
-| `bridge!` | `(bridge! self name info)` | Register/update bridge metadata and cached public key. |
-| `bridges` | `(bridges self)` | List configured bridge names. |
+| `bridge!` | `(bridge! self name interface info)` | Register/update bridge metadata and cached public key. |
+| `get` | `(get self path)` | Read staged content at path. |
 | `set!` | `(set! self path value)` | Stage local state mutation. |
-| `get` | `(get self path pinned? proof?)` | Read staged/historical value; optional content/pinned/proof bundle. |
-| `pin!` | `(pin! self path)` | Pin path into permanent chain retention. |
+| `resolve` | `(resolve self path pinned? proof? head)` | Resolve committed content, optionally including pin/proof detail. |
+| `trace` | `(trace self index path head)` | Serialize a proof view rooted at index/path. |
+| `pin!` | `(pin! self path response)` | Pin path into permanent chain retention, optionally from a prepared proof response. |
 | `unpin!` | `(unpin! self path)` | Remove previously pinned path. |
 | `synchronize` | `(synchronize self index)` | Serialize bridge-sync proof view at index. |
-| `resolve` | `(resolve self index path)` | Serialize resolved path view for remote verification. |
-| `step-bridge!` | `(step-bridge! self name)` | Fetch and verify bridge chain head into staged state. |
-| `step-chain!` | `(step-chain! self)` | Commit staged state to chain, sign, prune by window, return new size. |
-| `step-generate` | `(step-generate self)` | Generate ordered step operations (chain + bridges). |
+| `bridge-synchronize!` | `(bridge-synchronize! self name index response)` | Merge a prepared bridge synchronization response. |
+| `step!` | `(step! self unix-time)` | Commit staged state to chain, sign, prune by window, and return new size. |
 | `update-window` | `(update-window self window)` | Update the configured recent-history window and prune `temp` when it shrinks. |
 | `update-config!` | `(update-config! self path value)` | Update a configuration entry in place. |
 | `update-code!` | `(update-code! self class update!)` | Update one surface-level code object in place. |

--- a/info/src/content/docs/index.md
+++ b/info/src/content/docs/index.md
@@ -29,7 +29,7 @@ The Synchronic Web addresses that by treating state as a cryptographically linke
 ### Dynamic Object Structures
 
 The stack uses a minimal language and object protocol to encapsulate both data and behavior over time.
-Rather than hard-coding every interface in Rust, the runtime allows controlled Lisp-level composition of classes (`standard`, `tree`, `chain`, `configuration`, `ledger`) and query/step handlers.
+Rather than hard-coding every interface in Rust, the runtime allows controlled Lisp-level composition of classes (`standard`, `tree`, `chain`, `ledger`) and query/step handlers.
 This makes higher-level behavior evolvable without replacing the runtime substrate.
 In practice, this means teams can iterate on application semantics at the Lisp layer while retaining a stable underlying execution and persistence runtime.
 
@@ -50,7 +50,7 @@ All official resources are found in the following public repositories:
 
 1. [sync-web](https://github.com/sandialabs/sync-web): documentation hub and project entry point.
 2. [sync-journal](https://github.com/sandialabs/sync-journal): Rust runtime, HTTP interface, evaluator extensions, persistence.
-3. [sync-records](https://github.com/sandialabs/sync-records): Lisp class logic (`control`, `standard`, `tree`, `chain`, `configuration`, `ledger`).
+3. [sync-records](https://github.com/sandialabs/sync-records): Lisp class logic (`control`, `standard`, `tree`, `chain`, `ledger`, `interface`).
 4. [sync-services](https://github.com/sandialabs/sync-services): compose deployments and web services (`interface`, `gateway`, `explorer`, `workbench`, `file-system`).
 5. [sync-analysis](https://github.com/sandialabs/sync-analysis): load testing and network/simulation assets.
 

--- a/info/src/content/docs/operation.mdx
+++ b/info/src/content/docs/operation.mdx
@@ -100,15 +100,15 @@ Router mode is selected at startup:
 
 ## Network API
 
-Implemented by `sync-records/lisp/general.scm` on top of `control.scm` and `ledger.scm`.
+Implemented by `sync-records/lisp/interface.scm` on top of `control.scm`, `standard.scm`, and `ledger.scm`.
 Permission boundaries are central to safe operation, so operators should treat function families as security domains.
 
 ### Function Families
 
 | Family | Description | Functions |
 | --- | --- | --- |
-| Public (no authentication) | Read-only methods intended for external visibility without secrets. | `size`, `synchronize`, `resolve`, `information` |
-| Restricted (interface secret) | Stateful or sensitive operations that require interface authentication. | `get`, `set!`, `pin!`, `unpin!`, `general-bridge!`, `bridge!`, `bridges`, `general-batch!`, `configuration`, `step-generate`, `step-chain!`, `step-bridge!`, `*secret*` |
+| Public (no authentication) | Read-mostly methods intended for external visibility without secrets. | `size`, `synchronize`, `info`, `config`, `get`, `trace` |
+| Restricted (interface secret) | Stateful or sensitive operations that require interface authentication. | `resolve`, `set!`, `pin!`, `unpin!`, `bridge!`, `bridge-synchronize!`, `*step!*`, `*secret*` |
 | Root/Admin control | Root control commands for runtime mutation and administrative lifecycle management. | `*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*` |
 
 ### Function Reference
@@ -122,24 +122,22 @@ The same function names appear in Explorer/Workbench, automated scripts, and inc
 | --- | --- |
 | `size` | Current permanent-chain size |
 | `synchronize` | Serialize digest/proof data for bridge sync |
-| `resolve` | Resolve and serialize state at a path/index |
-| `information` | Public node metadata (e.g., public key/window) |
+| `info` | Public node metadata (for example public key and window) |
+| `config` | Full current config expression |
+| `get` | Read staged state content |
+| `trace` | Return serialized proof/path view rooted at an index |
 
 #### Restricted Functions
 
 | Function | Purpose |
 | --- | --- |
-| `get` | Read staged or historical data |
+| `resolve` | Resolve committed content, optionally with pin/proof detail |
 | `set!` | Stage a write |
 | `pin!` | Persist proof/data in permanent chain |
 | `unpin!` | Remove persisted pin |
-| `general-bridge!` | Register bridge from URL helper |
-| `bridge!` | Register bridge with explicit RPC handlers |
-| `bridges` | List configured bridges |
-| `configuration` | Return full public/private config |
-| `step-generate` | Build ordered step actions |
-| `step-chain!` | Commit staged state to chain |
-| `step-bridge!` | Sync state from a named bridge |
+| `bridge!` | Register bridge with remote interface and optional prefetched info |
+| `bridge-synchronize!` | Merge a prepared bridge synchronization response |
+| `*step!*` | Run interface stepping, including bridge synchronization |
 | `*secret*` | Rotate interface secret |
 
 #### Root/Admin Functions
@@ -186,8 +184,8 @@ This API is intentionally powerful and low-level, so access should be tightly co
 
 ### General API Bootstrap
 
-`general.scm` overlays the instantiated ledger object and dispatches `((function ...))` requests to public ledger methods, with permission checks on each call.
-It also adds one integration helper (`general-bridge!`) that composes the lower-level bridge registration flow.
+`interface.scm` overlays the instantiated ledger object and dispatches `((function ...))` requests to ledger and bridge-helper methods, with permission checks on each call.
+It also handles remote bridge fetch/merge flows before handing the final operation to `ledger`.
 
 #### General API Methods
 
@@ -195,21 +193,18 @@ It also adds one integration helper (`general-bridge!`) that composes the lower-
 | --- | --- | --- |
 | `size` | Public | Return permanent chain size. |
 | `synchronize` | Public | Return serialized sync proof at index. |
-| `resolve` | Public | Return serialized resolved path proof. |
-| `information` | Public | Return public node configuration. |
-| `get` | Restricted | Read staged or historical content. |
+| `info` | Public | Return public node configuration. |
+| `config` | Public | Return full inline ledger configuration. |
+| `get` | Public | Read staged content. |
+| `trace` | Public | Return serialized proof/path content rooted at an index. |
+| `resolve` | Restricted | Return resolved path content, optionally with pin/proof detail. |
 | `set!` | Restricted | Stage write to local state path. |
 | `pin!` | Restricted | Persist selected path/proof in permanent chain. |
 | `unpin!` | Restricted | Remove previously pinned path/proof. |
-| `general-bridge!` | Restricted | Add bridge from URL and auto-wire `information/synchronize/resolve` handlers. |
-| `bridge!` | Restricted | Add bridge with explicit handler expressions. |
-| `bridges` | Restricted | List configured bridge names. |
-| `general-batch!` | Restricted | Execute an ordered list of general-interface requests under one authenticated call. |
-| `configuration` | Restricted | Return full configuration (including private fields). |
-| `step-generate` | Restricted | Generate ordered step actions. |
-| `step-chain!` | Restricted | Commit staged state and advance chain. |
-| `step-bridge!` | Restricted | Synchronize a named bridge into local staged state. |
-| `*secret*` | Restricted | Rotate interface secret used by general API auth checks. |
+| `bridge!` | Restricted | Add bridge, fetching remote info when omitted. |
+| `bridge-synchronize!` | Restricted | Synchronize a named bridge into local staged state. |
+| `*step!*` | Restricted | Run bridge synchronization and local step progression. |
+| `*secret*` | Restricted | Rotate interface secret used by interface API auth checks. |
 
 Root commands (`*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*`) are also callable, but remain part of the control-plane surface and should be treated as admin-level operations.
 This keeps externally visible behavior stable while allowing implementation details inside ledger classes to evolve.
@@ -277,7 +272,7 @@ Secret rotation is the minimum operational hygiene task for any deployed environ
 ### Updating Runtime Logic
 
 Use root-level calls for controlled live updates.
-Typical update targets are: control hooks, standard, configuration, tree, chain, and ledger.
+Typical update targets are: control hooks, standard, tree, chain, interface, and ledger.
 Because these changes alter live semantics, apply them in lower environments first and validate with smoke checks before promotion.
 
 #### Update control hooks (`*set-query*`, `*set-step*`)
@@ -352,13 +347,13 @@ For step hook updates, use the same pattern with `*set-step*`.
   </TabItem>
 </Tabs>
 
-#### Update configuration state
+#### Inspect current config
 
 <Tabs syncKey="lisp-json">
   <TabItem label="Lisp">
 
 ```scheme
-((function configuration)
+((function config)
  (authentication "password"))
 ```
 
@@ -367,7 +362,7 @@ For step hook updates, use the same pattern with `*set-step*`.
 
 ```json
 {
-  "function": "configuration",
+  "function": "config",
   "authentication": {"*type/string*": "password"}
 }
 ```
@@ -375,7 +370,7 @@ For step hook updates, use the same pattern with `*set-step*`.
   </TabItem>
 </Tabs>
 
-For in-place configuration mutation, use root-level `*call*` and update `(control object ledger)` with the mutated object.
+For in-place configuration mutation, use the interface `*call*`/`*eval*` control path or the ledger's `update-config!` method from an authenticated admin flow.
 
 #### Update tree/chain/ledger classes
 

--- a/info/src/content/docs/usage.mdx
+++ b/info/src/content/docs/usage.mdx
@@ -47,7 +47,7 @@ Use it when you want precise control over requests, fast iteration on payload sh
 
 Typical Workbench workflow:
 
-1. Start from a known request pattern (for example `get`, `set!`, `pin!`, or `general-bridge!`).
+1. Start from a known request pattern (for example `get`, `set!`, `pin!`, or `bridge!`).
 2. Run the request in Scheme or JSON form and inspect the returned value.
 3. Iterate on arguments/authentication until behavior matches intent.
 4. Use the final request as a template for automation or service integration.
@@ -65,7 +65,7 @@ Typical Gateway workflow:
 
 1. Start with `GET /docs` to review request and response schemas.
 2. Use `GET /api/v1/general/size` or another stable route to validate connectivity.
-3. Execute public general operations through `GET` routes (for example `size`, `information`, and `resolve`).
+3. Execute public general operations through `GET` routes (for example `size`, `info`, and `trace`).
 4. Execute restricted `general` and optional `control` operations through authenticated `POST` routes.
 5. Move validated requests into application clients or automation scripts using the same gateway contracts.
 
@@ -244,13 +244,13 @@ You can copy them into Workbench first, then move them into automation once vali
   </TabItem>
 </Tabs>
 
-#### Bridge (`general-bridge!`)
+#### Bridge (`bridge!`)
 
 <Tabs syncKey="lisp-json">
   <TabItem label="Lisp">
 
 ```scheme
-((function general-bridge!)
+((function bridge!)
  (arguments ((name journal_b)
              (interface "http://journal-b.example.org/interface")))
  (authentication "password"))
@@ -261,7 +261,7 @@ You can copy them into Workbench first, then move them into automation once vali
 
 ```json
 {
-  "function": "general-bridge!",
+  "function": "bridge!",
   "arguments": {
     "name": "journal_b",
     "interface": {"*type/string*": "http://journal-b.example.org/interface"}


### PR DESCRIPTION
- update development docs to describe the interface-driven runtime and inline ledger config model
- refresh operation and usage docs for the current bridge, config, info, and trace APIs
- remove stale references to the old general/configuration surface and align the index page with the active record modules