### PR TITLE
Align sync-web docs with the root rename

### DIFF
--- a/info/package.json
+++ b/info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sync-web-info",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Synchronic Web documentation site (Astro + Starlight).",
   "scripts": {
     "dev": "astro dev",

--- a/info/src/content/docs/development.md
+++ b/info/src/content/docs/development.md
@@ -19,7 +19,7 @@ At runtime, each query is evaluated against the current `*sync-state*` root.
 The left side carries executable logic and the right side carries persistent state.
 The general stack boot flow is:
 
-1. Install `control.scm`.
+1. Install `root.scm`.
 2. Install/instantiate `standard.scm`.
 3. Install class definitions (`log-chain.scm`, `tree.scm`, `ledger.scm`).
 4. Instantiate and store `ledger` object with inline config state.

--- a/info/src/content/docs/index.md
+++ b/info/src/content/docs/index.md
@@ -50,7 +50,7 @@ All official resources are found in the following public repositories:
 
 1. [sync-web](https://github.com/sandialabs/sync-web): documentation hub and project entry point.
 2. [sync-journal](https://github.com/sandialabs/sync-journal): Rust runtime, HTTP interface, evaluator extensions, persistence.
-3. [sync-records](https://github.com/sandialabs/sync-records): Lisp class logic (`control`, `standard`, `tree`, `chain`, `ledger`, `interface`).
+3. [sync-records](https://github.com/sandialabs/sync-records): Lisp class logic (`root`, `standard`, `tree`, `chain`, `ledger`, `interface`).
 4. [sync-services](https://github.com/sandialabs/sync-services): compose deployments and web services (`interface`, `gateway`, `explorer`, `workbench`, `file-system`).
 5. [sync-analysis](https://github.com/sandialabs/sync-analysis): load testing and network/simulation assets.
 

--- a/info/src/content/docs/operation.mdx
+++ b/info/src/content/docs/operation.mdx
@@ -91,7 +91,7 @@ It serves runtime query routes and UI routes:
 | `/api/v1/...` | Versioned gateway API endpoints proxied to gateway service. |
 | `/explorer/` | Browser UI with dedicated `Ledger` and `Stage` modes for committed browsing and local staged editing. |
 | `/workbench/` | Developer-oriented query workspace with API aids. |
-| SMB share | File-system projection exposing `/stage`, `/ledger`, and `/control/pin`. |
+| SMB share | File-system projection exposing `/stage`, `/ledger`, and `/root/pin`. |
 
 Router mode is selected at startup:
 
@@ -100,7 +100,7 @@ Router mode is selected at startup:
 
 ## Network API
 
-Implemented by `sync-records/lisp/interface.scm` on top of `control.scm`, `standard.scm`, and `ledger.scm`.
+Implemented by `sync-records/lisp/interface.scm` on top of `root.scm`, `standard.scm`, and `ledger.scm`.
 Permission boundaries are central to safe operation, so operators should treat function families as security domains.
 
 ### Function Families
@@ -109,7 +109,7 @@ Permission boundaries are central to safe operation, so operators should treat f
 | --- | --- | --- |
 | Public (no authentication) | Read-mostly methods intended for external visibility without secrets. | `size`, `synchronize`, `info`, `config`, `get`, `trace` |
 | Restricted (interface secret) | Stateful or sensitive operations that require interface authentication. | `resolve`, `set!`, `pin!`, `unpin!`, `bridge!`, `bridge-synchronize!`, `*step!*`, `*secret*` |
-| Root/Admin control | Root control commands for runtime mutation and administrative lifecycle management. | `*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*` |
+| Root/Admin | Root commands for runtime mutation and administrative lifecycle management. | `*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*` |
 
 ### Function Reference
 
@@ -151,13 +151,13 @@ The same function names appear in Explorer/Workbench, automated scripts, and inc
 | `*set-step*` | Replace step handler |
 | `*set-query*` | Replace query handler |
 
-### Control Plane API
+### Root Plane API
 
-`control.scm` provides authentication of privileged operations, enforces root mutation/update discipline, and defines hook points for query and step behavior.
+`root.scm` provides authentication of privileged operations, enforces root mutation/update discipline, and defines hook points for query and step behavior.
 
 #### Root Object Methods
 
-These are the public root methods exposed by the control module's base record object.
+These are the public root methods exposed by the root module's base record object.
 
 | Method | Signature | Description |
 | --- | --- | --- |
@@ -167,16 +167,16 @@ These are the public root methods exposed by the control module's base record ob
 | `equal?` | `((root 'equal?) source target)` | Exact structural equality check between two paths. |
 | `equivalent?` | `((root 'equivalent?) source target)` | Digest-equivalence check between two paths. |
 
-#### Root Control Commands
+#### Root Commands
 
-These are public control commands handled by the transition function in `control.scm`.
+These are public root commands handled by the transition function in `root.scm`.
 
 | Command | Signature | Description |
 | --- | --- | --- |
 | `*eval*` | `(*eval* <admin-secret> <expression>)` | Evaluate expression in admin context. |
 | `*call*` | `(*call* <admin-secret> <function>)` | Invoke function with `root` object and persist resulting state. |
 | `*step*` | `(*step* <admin-secret>)` | Execute configured step handler pipeline. |
-| `*set-secret*` | `(*set-secret* <old> <new>)` | Rotate admin secret used by control plane. |
+| `*set-secret*` | `(*set-secret* <old> <new>)` | Rotate admin secret used by root plane. |
 | `*set-step*` | `(*set-step* <admin-secret> <step-function>)` | Replace step handler logic. |
 | `*set-query*` | `(*set-query* <admin-secret> <query-function>)` | Replace query handler logic. |
 
@@ -206,7 +206,7 @@ It also handles remote bridge fetch/merge flows before handing the final operati
 | `*step!*` | Restricted | Run bridge synchronization and local step progression. |
 | `*secret*` | Restricted | Rotate interface secret used by interface API auth checks. |
 
-Root commands (`*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*`) are also callable, but remain part of the control-plane surface and should be treated as admin-level operations.
+Root commands (`*eval*`, `*call*`, `*step*`, `*set-secret*`, `*set-step*`, `*set-query*`) are also callable, but remain part of the root-plane surface and should be treated as admin-level operations.
 This keeps externally visible behavior stable while allowing implementation details inside ledger classes to evolve.
 
 ## Operations
@@ -272,10 +272,10 @@ Secret rotation is the minimum operational hygiene task for any deployed environ
 ### Updating Runtime Logic
 
 Use root-level calls for controlled live updates.
-Typical update targets are: control hooks, standard, tree, chain, interface, and ledger.
+Typical update targets are: root hooks, standard, tree, chain, interface, and ledger.
 Because these changes alter live semantics, apply them in lower environments first and validate with smoke checks before promotion.
 
-#### Update control hooks (`*set-query*`, `*set-step*`)
+#### Update root hooks (`*set-query*`, `*set-step*`)
 
 <Tabs syncKey="lisp-json">
   <TabItem label="Lisp">
@@ -320,8 +320,8 @@ For step hook updates, use the same pattern with `*set-step*`.
 (*call* "admin-password"
   (lambda (root)
     (define standard-cls '(define-class (standard) ...))
-    ((root 'set!) '(control class standard) standard-cls)
-    ((root 'set!) '(control object standard)
+    ((root 'set!) '(root class standard) standard-cls)
+    ((root 'set!) '(root object standard)
       (((eval (caddr standard-cls)) #f standard-cls)))))
 ```
 
@@ -338,7 +338,7 @@ For step hook updates, use the same pattern with `*set-step*`.
     [
       "begin",
       ["define", "standard-cls", {"*type/quoted*": ["define-class", ["standard"], "..."]}],
-      [["root", {"*type/quoted*": "set!"}], {"*type/quoted*": ["control", "class", "standard"]}, "standard-cls"]
+      [["root", {"*type/quoted*": "set!"}], {"*type/quoted*": ["root", "class", "standard"]}, "standard-cls"]
     ]
   ]
 ]
@@ -370,15 +370,15 @@ For step hook updates, use the same pattern with `*set-step*`.
   </TabItem>
 </Tabs>
 
-For in-place configuration mutation, use the interface `*call*`/`*eval*` control path or the ledger's `update-config!` method from an authenticated admin flow.
+For in-place configuration mutation, use the interface `*call*`/`*eval*` root path or the ledger's `update-config!` method from an authenticated admin flow.
 
 #### Update tree/chain/ledger classes
 
 Operational pattern:
 
-1. Replace class definition under `(control class <name>)`.
+1. Replace class definition under `(root class <name>)`.
 2. Rebuild affected object with `standard.make`.
-3. Reinsert updated object under `(control object ledger)` or related path.
+3. Reinsert updated object under `(root object ledger)` or related path.
 4. Validate with smoke tests.
 
 <Tabs syncKey="lisp-json">
@@ -388,7 +388,7 @@ Operational pattern:
 (*call* "admin-password"
   (lambda (root)
     (define ledger-cls '(define-class (ledger) ...))
-    ((root 'set!) '(control class ledger) ledger-cls)
+    ((root 'set!) '(root class ledger) ledger-cls)
     ...))
 ```
 

--- a/info/src/content/docs/usage.mdx
+++ b/info/src/content/docs/usage.mdx
@@ -66,7 +66,7 @@ Typical Gateway workflow:
 1. Start with `GET /docs` to review request and response schemas.
 2. Use `GET /api/v1/general/size` or another stable route to validate connectivity.
 3. Execute public general operations through `GET` routes (for example `size`, `info`, and `trace`).
-4. Execute restricted `general` and optional `control` operations through authenticated `POST` routes.
+4. Execute restricted `general` and optional `root` operations through authenticated `POST` routes.
 5. Move validated requests into application clients or automation scripts using the same gateway contracts.
 
 The Gateway is best for service integration because it standardizes journal calls into HTTP endpoints with explicit request validation.
@@ -84,7 +84,7 @@ Typical File System workflow:
 2. Browse `/ledger/state` for current committed content.
 3. Traverse `/ledger/previous/<index>/state` for prior committed states.
 4. Traverse `/ledger/bridge/<name>/...` for recursively bridged ledger state.
-5. Use `/control/pin` for explicit pin and unpin directives on discovered ledger paths.
+5. Use `/root/pin` for explicit pin and unpin directives on discovered ledger paths.
 
 The File System service is best for shell tools, editors, archives, source trees, and other workflows that already expect a hierarchical filesystem.
 
@@ -107,7 +107,7 @@ Filesystem projection overview:
 │           ├── state/
 │           ├── bridge/
 │           └── previous/
-└── control/
+└── root/
     └── pin
 ```
 
@@ -116,7 +116,7 @@ Key semantics:
 - `/stage` is mutable.
 - `/ledger/...` is readable but content-immutable.
 - once you enter any `state/` subtree, remaining path segments are ordinary file and directory names.
-- `/control/pin` is a synthetic UTF-8 control file for pin and unpin directives against discovered `/ledger/...` paths.
+- `/root/pin` is a synthetic UTF-8 root file for pin and unpin directives against discovered `/ledger/...` paths.
 
 ## Programmatic API
 


### PR DESCRIPTION
Update the docs site to use root.scm, (root ...) internal paths, and /root surfaces where sync-records and sync-services now use the renamed runtime layer.

Refresh the usage and operation guides so gateway admin routes and file-system pin examples use root terminology consistently.

Bump the docs-site package version to 1.0.2 for the downstream terminology update.