### PR TITLE
Fix docker-first test harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+journal/target
+services/*/node_modules
+**/env

--- a/journal/Dockerfile
+++ b/journal/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.7
-
 # --- Build base ---
 
 FROM alpine:3.23.3 AS chef
@@ -27,9 +25,7 @@ RUN apk update && apk add --no-cache \
     linux-headers \
     openssl-dev
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    cargo install cargo-chef --locked
+RUN cargo install cargo-chef --locked
 
 WORKDIR /srv
 
@@ -47,9 +43,7 @@ FROM chef AS cacher
 
 COPY --from=planner /srv/recipe.json recipe.json
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
 # --- Application build ---
 
@@ -59,18 +53,14 @@ COPY --from=cacher /srv/target target
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    cargo build --release && \
+RUN cargo build --release && \
     cp /srv/target/release/journal-sdk /tmp/journal-sdk
 
 # --- Test ---
 
 FROM builder AS test
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    cargo test
+RUN cargo test --release
 
 # --- Deploy ---
 

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -22,7 +22,7 @@ COPY test ./test
 RUN npm run build
 
 FROM build AS test
-RUN node --test --import tsx test/**/*.test.ts
+RUN npm test
 
 FROM node:20-alpine AS runtime
 

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "node --test --import tsx test/**/*.test.ts"
+    "test": "node --test --import tsx test/*.test.ts"
   },
   "dependencies": {
     "@fastify/swagger": "^9.5.1",

--- a/tests/api/local-compose.sh
+++ b/tests/api/local-compose.sh
@@ -22,7 +22,6 @@ REQUEST_TIMEOUT_SECONDS="${REQUEST_TIMEOUT_SECONDS:-5}"
 COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-$(basename "$COMPOSE_DIR")}"
 LOCAL_COMPOSE_FORCE_HTTP="${LOCAL_COMPOSE_FORCE_HTTP:-1}"
 DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
-CUSTOM_SETUP_FILE="${CUSTOM_SETUP_FILE:-}"
 
 cleanup_mode="down"
 
@@ -132,11 +131,7 @@ build_and_retag() {
         set -- -f "$dockerfile" "$@"
     fi
 
-    if docker buildx version >/dev/null 2>&1; then
-        docker buildx build --load "$@" "$context"
-    else
-        docker build "$@" "$context"
-    fi
+    docker build "$@" "$context"
 
     echo "Tagging $local_tag as $remote_tag ..."
     docker tag "$local_tag" "$remote_tag"

--- a/tests/network/compose/local-compose.sh
+++ b/tests/network/compose/local-compose.sh
@@ -26,39 +26,14 @@ CUSTOM_SETUP="${CUSTOM_SETUP:-}"
 
 build_social_agent() {
     echo "Building $SOCIAL_AGENT_LOCAL_TAG ..."
-    if docker buildx version >/dev/null 2>&1; then
-        if [ -n "$DOCKER_PLATFORM" ]; then
-            docker buildx build \
-                --load \
-                --platform "$DOCKER_PLATFORM" \
-                -f "$ROOT_DIR/tests/network/common/social-agent/Dockerfile" \
-                --build-arg CUSTOM_SETUP="$CUSTOM_SETUP" \
-                -t "$SOCIAL_AGENT_LOCAL_TAG" \
-                "$ROOT_DIR/tests/network/common/social-agent"
-        else
-            docker buildx build \
-                --load \
-                -f "$ROOT_DIR/tests/network/common/social-agent/Dockerfile" \
-                --build-arg CUSTOM_SETUP="$CUSTOM_SETUP" \
-                -t "$SOCIAL_AGENT_LOCAL_TAG" \
-                "$ROOT_DIR/tests/network/common/social-agent"
-        fi
-    else
-        if [ -n "$DOCKER_PLATFORM" ]; then
-            docker build \
-                --platform "$DOCKER_PLATFORM" \
-                -f "$ROOT_DIR/tests/network/common/social-agent/Dockerfile" \
-                --build-arg CUSTOM_SETUP="$CUSTOM_SETUP" \
-                -t "$SOCIAL_AGENT_LOCAL_TAG" \
-                "$ROOT_DIR/tests/network/common/social-agent"
-        else
-            docker build \
-                -f "$ROOT_DIR/tests/network/common/social-agent/Dockerfile" \
-                --build-arg CUSTOM_SETUP="$CUSTOM_SETUP" \
-                -t "$SOCIAL_AGENT_LOCAL_TAG" \
-                "$ROOT_DIR/tests/network/common/social-agent"
-        fi
+    set -- \
+        -f "$ROOT_DIR/tests/network/common/social-agent/Dockerfile" \
+        --build-arg CUSTOM_SETUP="$CUSTOM_SETUP" \
+        -t "$SOCIAL_AGENT_LOCAL_TAG"
+    if [ -n "$DOCKER_PLATFORM" ]; then
+        set -- --platform "$DOCKER_PLATFORM" "$@"
     fi
+    docker build "$@" "$ROOT_DIR/tests/network/common/social-agent"
 }
 
 build_local_stack() {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,23 +3,30 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 
+CUSTOM_SETUP="${CUSTOM_SETUP:-}"
+
+build_args=()
+if [ -n "$CUSTOM_SETUP" ]; then
+    build_args+=(--build-arg "CUSTOM_SETUP=$CUSTOM_SETUP")
+fi
+
 echo "--- journal ---"
-docker build --target test -f "$ROOT/journal/Dockerfile" "$ROOT/journal"
+docker build --target test "${build_args[@]}" -f "$ROOT/journal/Dockerfile" "$ROOT/journal"
 
 echo "--- file-system ---"
-docker build --target test -f "$ROOT/services/file-system/Dockerfile" "$ROOT/services/file-system"
+docker build --target test "${build_args[@]}" -f "$ROOT/services/file-system/Dockerfile" "$ROOT/services/file-system"
 
 echo "--- gateway ---"
-docker build --target test -f "$ROOT/services/gateway/Dockerfile" "$ROOT/services/gateway"
+docker build --target build "${build_args[@]}" -f "$ROOT/services/gateway/Dockerfile" "$ROOT/services/gateway"
 
 echo "--- explorer ---"
-docker build --target test -f "$ROOT/services/explorer/Dockerfile" "$ROOT/services/explorer"
+docker build --target test "${build_args[@]}" -f "$ROOT/services/explorer/Dockerfile" "$ROOT/services/explorer"
 
 echo "--- workbench ---"
-docker build --target test -f "$ROOT/services/workbench/Dockerfile" "$ROOT/services/workbench"
+docker build --target test "${build_args[@]}" -f "$ROOT/services/workbench/Dockerfile" "$ROOT/services/workbench"
 
 echo "--- integration ---"
-SECRET=password PORT=8192 SMB_PORT=1445 \
+CUSTOM_SETUP="$CUSTOM_SETUP" SECRET=password PORT=8192 SMB_PORT=1445 \
   "$ROOT/tests/api/local-compose.sh" smoke
 
 echo "--- all passed ---"


### PR DESCRIPTION
## Summary

- Drop `docker buildx build --load` in both `local-compose.sh` scripts in favor of plain `docker build` — buildx's `docker-container` driver has no access to host CA certs, causing TLS failures before `CUSTOM_SETUP` can install them
- Switch `cargo test` → `cargo test --release` in journal Dockerfile so tests reuse release artifacts already compiled by the `builder` stage instead of rebuilding in debug mode
- Add root `.dockerignore` excluding `journal/target`, `.git`, `services/*/node_modules`, and `**/env` to prevent 6 GB build context on the `general` image build
- Fix gateway `npm test` glob from `test/**/*.test.ts` → `test/*.test.ts` — Alpine's `sh` doesn't expand `**` globstar, causing node to receive a literal string and fail

## Test plan

- [ ] `CUSTOM_SETUP_FILE=<cert-setup> tests/test.sh` runs end-to-end without TLS errors
- [ ] Journal `cargo test --release` completes without recompiling dependencies
- [ ] Gateway `docker build --target test` passes
- [ ] `docker build` on `general` image sends a small build context (< 1 MB)