### PR TITLE
test: update crypto error expectation

### DIFF
--- a/journal/tests/crypto.rs
+++ b/journal/tests/crypto.rs
@@ -54,6 +54,6 @@ fn test_failure() {
     );
     assert1(
         "(let ((keys (crypto-generate #u(0)))) (crypto-verify (cdr (crypto-generate #u(1))) (crypto-sign (car keys) #u(1)) #u(1)))",
-        "(error 'crypto-error \"cryptographic library encountered unexpected error\")",
+        "(error 'crypto-error \"cryptographic library encountered unexpected error\" ((data (\"cryptographic library encountered unexpected error\"))))",
     );
 }


### PR DESCRIPTION
Summary
- Update the crypto failure test to expect the current structured error envelope with `data` details.

Testing
- `cd journal && cargo test --test crypto`
