### PR TITLE
ci: promote validated image builds

### DIFF
--- a/.github/scripts/promote-image.sh
+++ b/.github/scripts/promote-image.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_name="$1"
+version_file="${2:-VERSION}"
+
+repo="ghcr.io/${GITHUB_REPOSITORY}/${image_name}"
+version="$(cat "$version_file")"
+
+lookup_head_sha() {
+  local response
+  response="$(curl -fsSL \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")"
+  jq -r '.[0].head.sha // empty' <<<"$response"
+}
+
+head_sha="$(lookup_head_sha)"
+if [[ -z "$head_sha" ]]; then
+  echo "No associated pull request found for ${GITHUB_SHA}; using main commit SHA." >&2
+  head_sha="$GITHUB_SHA"
+fi
+
+source="${repo}:sha-${head_sha}"
+echo "Promoting ${source} to ${repo}:latest and ${repo}:${version}"
+
+docker buildx imagetools inspect "$source" >/dev/null
+
+docker buildx imagetools create \
+  -t "${repo}:latest" \
+  -t "${repo}:${version}" \
+  "$source"

--- a/.github/workflows/journal.yml
+++ b/.github/workflows/journal.yml
@@ -78,7 +78,6 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/journal-sdk:pr-validation
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache,mode=max
       - name: Build and push SHA-tagged journal-sdk validation image
         if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         uses: docker/build-push-action@v6

--- a/.github/workflows/journal.yml
+++ b/.github/workflows/journal.yml
@@ -32,7 +32,7 @@ jobs:
 
   test-journal:
     needs: changes
-    if: needs.changes.outputs.journal == 'true'
+    if: needs.changes.outputs.journal == 'true' || needs.changes.outputs.version == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
   build-journal-sdk:
     needs: [changes, test-journal]
-    if: needs.changes.outputs.journal == 'true' && needs.test-journal.result == 'success'
+    if: (needs.changes.outputs.journal == 'true' || needs.changes.outputs.version == 'true') && needs.test-journal.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,6 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Github registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -66,20 +67,32 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - name: Build journal-sdk (PR/non-main validation)
-        if: github.ref != 'refs/heads/main'
+      - name: Build journal-sdk pull request validation image
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: journal
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/journal-sdk:latest
+          tags: ghcr.io/${{ github.repository }}/journal-sdk:pr-validation
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache,mode=max
-      - name: Build and push journal-sdk (main)
-        if: github.ref == 'refs/heads/main'
+      - name: Build and push SHA-tagged journal-sdk validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: journal
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/journal-sdk:sha-${{ github.sha }}
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/journal-sdk:cache,mode=max
+      - name: Build and push journal-sdk for direct main journal changes
+        if: github.ref == 'refs/heads/main' && needs.changes.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: journal
@@ -93,7 +106,7 @@ jobs:
 
   compose-smoke:
     needs: [changes, test-journal, build-journal-sdk]
-    if: always() && !cancelled() && !failure()
+    if: always() && github.ref != 'refs/heads/main' && !cancelled() && !failure()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,6 +125,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -119,8 +133,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - name: Tag version
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/journal-sdk:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/journal-sdk:latest"
+      - name: Promote validated image
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh journal-sdk

--- a/.github/workflows/services-explorer.yml
+++ b/.github/workflows/services-explorer.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -42,19 +42,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run unit tests
-        if: steps.filter.outputs.service == 'true'
+        if: steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true'
         run: docker build --target test services/explorer
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/explorer
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/explorer:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/explorer:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/explorer
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/explorer:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/explorer
@@ -62,9 +71,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/explorer:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/explorer:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/explorer:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh explorer

--- a/.github/workflows/services-file-system.yml
+++ b/.github/workflows/services-file-system.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -42,19 +42,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run unit tests
-        if: steps.filter.outputs.service == 'true'
+        if: steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true'
         run: docker build --target test services/file-system
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/file-system
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/file-system:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/file-system:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/file-system
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/file-system:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/file-system
@@ -62,9 +71,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/file-system:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/file-system:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/file-system:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh file-system

--- a/.github/workflows/services-gateway.yml
+++ b/.github/workflows/services-gateway.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -42,19 +42,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run unit tests
-        if: steps.filter.outputs.service == 'true'
+        if: steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true'
         run: docker build --target test services/gateway
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/gateway
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/gateway:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/gateway:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/gateway
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/gateway:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/gateway
@@ -62,9 +71,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/gateway:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/gateway:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/gateway:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh gateway

--- a/.github/workflows/services-identity-provider.yml
+++ b/.github/workflows/services-identity-provider.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -41,25 +41,32 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/identity-provider
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/identity-provider:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/identity-provider:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/identity-provider
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/identity-provider:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/identity-provider
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/identity-provider:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/identity-provider:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/identity-provider:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh identity-provider

--- a/.github/workflows/services-router.yml
+++ b/.github/workflows/services-router.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -41,25 +41,32 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/router
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/router:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/router:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/router
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/router:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/router
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/router:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/router:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/router:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh router

--- a/.github/workflows/services-workbench.yml
+++ b/.github/workflows/services-workbench.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Login to Github registry
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -42,19 +42,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run unit tests
-        if: steps.filter.outputs.service == 'true'
+        if: steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true'
         run: docker build --target test services/workbench
-      - name: Build Docker image (PR/non-main validation)
-        if: github.ref != 'refs/heads/main' && steps.filter.outputs.service == 'true'
+      - name: Build pull request validation image
+        if: github.event_name == 'pull_request' && steps.filter.outputs.service == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/workbench
           target: runtime
           platforms: linux/amd64
           push: false
-          tags: ghcr.io/${{ github.repository }}/workbench:latest
-      - name: Build and push multi-arch Docker images
-        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true'
+          tags: ghcr.io/${{ github.repository }}/workbench:pr-validation
+      - name: Build and push SHA-tagged validation image
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main' && (steps.filter.outputs.service == 'true' || steps.filter.outputs.version == 'true')
+        uses: docker/build-push-action@v6
+        with:
+          context: services/workbench
+          target: runtime
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/workbench:sha-${{ github.sha }}
+      - name: Build and push latest image for direct main service changes
+        if: github.ref == 'refs/heads/main' && steps.filter.outputs.service == 'true' && steps.filter.outputs.version != 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/workbench
@@ -62,9 +71,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.repository }}/workbench:latest
-      - name: Tag version
+      - name: Promote validated image
         if: github.ref == 'refs/heads/main' && steps.filter.outputs.version == 'true'
-        run: |
-          VERSION="$(cat VERSION)"
-          TAG="ghcr.io/${{ github.repository }}/workbench:$VERSION"
-          docker buildx imagetools create -t "$TAG" "ghcr.io/${{ github.repository }}/workbench:latest"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/promote-image.sh workbench

--- a/journal/Cargo.toml
+++ b/journal/Cargo.toml
@@ -32,7 +32,7 @@ crystals-dilithium = "1.0.0"
 pqcrypto = "0.17.0"
 tokio = { version = "1.0", features = ["time", "rt", "rt-multi-thread", "macros"] }
 serde_json = "1.0.149"
-time = { version = "0.3.44", features = ["formatting"] }
+time = { version = "=0.3.44", features = ["formatting"] }
 
 [dev-dependencies]
 mockito = "1.4.0"


### PR DESCRIPTION
## Summary

- Push SHA-tagged validation images from non-main branch builds, including version-bump branches.
- Promote the validated SHA image to `latest` and `VERSION` on main instead of rebuilding release images after merge.
- Keep `pull_request` image builds local-only so fork/PR validation does not need package writes.
- Skip compose smoke on main; it remains a pre-merge validation check.
- Pin journal `time` to `0.3.44` to avoid the `cookie`/`time` compile conflict from floating dependency resolution.

## Testing

- Parsed workflow YAML with Python `yaml.safe_load`.
- `cd journal && cargo test --no-run`

## Notes/Risks

- Main promotion discovers the associated PR head SHA via GitHub's commit pulls API and falls back to the main SHA for direct pushes.
- For reliable fast releases, wait for branch/PR SHA image builds to complete before merging a version bump.
- Longer term, journal should likely commit `Cargo.lock` or otherwise make Rust image builds fully deterministic.
